### PR TITLE
Replace torchvision dependency with lightweight transforms

### DIFF
--- a/test_play_data.py
+++ b/test_play_data.py
@@ -1,9 +1,9 @@
 import json
 import os
 import torch
-import torchvision.transforms as transforms
 from PIL import Image
 from model_parts.unet import UNet
+from utils.transforms import get_transforms, tensor_to_pil
 
 try:
     with open('config/config.json', 'r') as config_file:
@@ -39,10 +39,7 @@ except RuntimeError as e:
 model = model.to(device)
 model.eval()
 
-before_transform = transforms.Compose([
-    transforms.Resize((img_height, img_width), antialias=True),            
-    transforms.ToTensor(),
-])
+before_transform = get_transforms(config)
 
 def process_single_image(input_img_path, output_img_path, before_transform):
     try:
@@ -61,7 +58,7 @@ def process_single_image(input_img_path, output_img_path, before_transform):
         output_batch = model(input_batch)
     
     output_tensor = output_batch.squeeze(0).cpu()
-    output_img = transforms.ToPILImage()(output_tensor)
+    output_img = tensor_to_pil(output_tensor)
 
     try:
         output_img.save(output_img_path)

--- a/utils/data_loading.py
+++ b/utils/data_loading.py
@@ -1,18 +1,12 @@
 # /utils/data_loading.py
-from torchvision import transforms
 from torch.utils.data import DataLoader
 from utils.pairedimage_dataset import PairedImageDataset
+from utils.transforms import get_transforms as _build_transforms
+
 
 def get_transforms(config):
-    """Generate torchvision transforms based on config."""
-    img_height = config['training']['img_height']
-    img_width = config['training']['img_width']
-
-    transform = transforms.Compose([
-        transforms.Resize((img_height, img_width)),
-        transforms.ToTensor(),
-    ])
-    return transform
+    """Thin wrapper so existing imports keep working."""
+    return _build_transforms(config)
 
 def get_dataloaders(config):
     """Create DataLoader for training, validation, and testing datasets."""


### PR DESCRIPTION
## Summary
- replace the buggy torchvision-based transform module with a lightweight PIL/PyTorch implementation that avoids circular imports
- update the data loading helpers to use the new transform pipeline while keeping their public surface unchanged
- switch the play data script to the shared utilities so it no longer imports torchvision and can export tensors without NumPy

## Testing
- python - <<'PY'
from PIL import Image
import torch
from utils.transforms import get_transforms, tensor_to_pil

config = {
    'training': {'img_width': 16, 'img_height': 10},
    'augmentation': {'color_jitter': {'enabled': False}}
}

transform = get_transforms(config)
img = Image.new('RGB', (8, 8), color='red')
tensor = transform(img)
print(tensor.shape, tensor.min().item(), tensor.max().item())
img2 = tensor_to_pil(tensor)
print(img2.size, img2.mode)
PY
- pytest test_play_data.py *(fails: torch requires a NumPy build that is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e400a2e7588333b7dacab84e8f7f13